### PR TITLE
Fix gem name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Adds support for citext to active_record
 
 Add this line to your application's Gemfile:
 
-    gem 'activerecord-postgres-citext'
+    gem 'activerecord-postgresql-citext'
 
 And then execute:
 
@@ -14,7 +14,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install activerecord-postgres-citext
+    $ gem install activerecord-postgresql-citext
 
 ## Usage
 


### PR DESCRIPTION
https://rubygems.org/gems/activerecord-postgres-citext does not exist but https://rubygems.org/gems/activerecord-postgresql-citext does